### PR TITLE
Fix undefined var

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ config.read('settings.ini')
 profile = config['Profile']
 gear = config['Gear']
 enchant = config['Enchant']
+c_profilemaxid=0
 
 c_profilename=profile['profilename']
 c_profileid=int(profile['profileid'])


### PR DESCRIPTION
Fixed "NameError: name 'c_profilemaxid' is not defined" at launch